### PR TITLE
Add fuzzing code for Nat, Modulus, and Int

### DIFF
--- a/int_fuzz.go
+++ b/int_fuzz.go
@@ -1,0 +1,269 @@
+// +build gofuzz
+
+package saferith
+
+import (
+	"encoding/binary"
+	"errors"
+	"math/big"
+)
+
+func FuzzInt(data []byte) int {
+	FuzzIntSetBig(data)
+	FuzzIntSetBytes(data)
+	FuzzIntSetNat(data)
+	FuzzIntSetInt(data)
+	FuzzIntSetUint64(data)
+	FuzzIntUnmarshalBinary(data)
+
+	FuzzIntArithmetic(data)
+	FuzzIntResize(data)
+	return 0
+}
+
+func FuzzIntSetBig(data []byte) int {
+	var x big.Int
+	x.SetBytes(data)
+
+	l := len(data)
+	for size := 0; size < l; size++ {
+		var i Int
+		i.SetBig(&x, size)
+		runAllInt(&i)
+	}
+
+	return 0
+}
+
+func FuzzIntSetBytes(data []byte) int {
+	var i Int
+	i.SetBytes(data)
+	runAllInt(&i)
+	return 0
+}
+
+func FuzzIntSetNat(data []byte) int {
+	var n Nat
+	n.SetBytes(data)
+
+	var i Int
+	i.SetNat(&n)
+	runAllInt(&i)
+	return 0
+}
+
+func FuzzIntSetInt(data []byte) int {
+	var x Int
+	x.SetBytes(data)
+
+	var i Int
+	i.SetInt(&x)
+	runAllInt(&i)
+	return 0
+}
+
+func FuzzIntSetUint64(data []byte) int {
+	l := len(data)
+	if l != 8 {
+		return -1
+	}
+
+	x := binary.LittleEndian.Uint64(data)
+
+	var i Int
+	i.SetUint64(x)
+	runAllInt(&i)
+	return 0
+}
+
+func FuzzIntUnmarshalBinary(data []byte) int {
+	if len(data) < 1 {
+		return -1
+	}
+
+	var i Int
+	if err := i.UnmarshalBinary(data); err != nil {
+		panic(err)
+	}
+
+	runAllInt(&i)
+	return 0
+}
+
+func FuzzIntArithmetic(data []byte) int {
+	FuzzIntModularArithmetic(data)
+	FuzzIntSetModSymmetric(data)
+	FuzzIntExpI(data)
+	FuzzIntAdd(data)
+	FuzzIntMul(data)
+	FuzzIntNeg(data)
+	return 0
+}
+
+func FuzzIntModularArithmetic(data []byte) int {
+	if isZero(data) {
+		return -1
+	}
+
+	p := ModulusFromBytes(data)
+
+	var i Int
+	i.CheckInRange(p)
+	i.Mod(p)
+	return 0
+}
+
+func FuzzIntSetModSymmetric(data []byte) int {
+	z, p, err := getOneNatAndOneMod(data)
+	if err != nil {
+		return -1
+	}
+
+	var i Int
+	i.SetModSymmetric(z, p)
+	return 0
+}
+
+func FuzzIntExpI(data []byte) int {
+	i, x, p, err := getOneIntAndOneNatAndOneMod(data)
+	if err != nil {
+		return -1
+	}
+
+	var z Nat
+	z.ExpI(x, i, p)
+	return 0
+}
+
+func FuzzIntAdd(data []byte) int {
+	if len(data) < 2 {
+		return -1
+	}
+
+	cap := int(data[0])
+	x, y, err := getTwoInts(data[1:])
+	if err != nil {
+		return -1
+	}
+
+	var a Int
+	var b Int
+	a.Add(x, y, cap)
+	b.Add(y, x, cap)
+	if a.Eq(&b) != 1 {
+		panic("Int.Add: (x+y)!=(y+x)")
+	}
+
+	return 0
+}
+
+func FuzzIntMul(data []byte) int {
+	if len(data) < 2 {
+		return -1
+	}
+
+	cap := int(data[0])
+	x, y, err := getTwoInts(data[1:])
+	if err != nil {
+		return -1
+	}
+
+	var a Int
+	var b Int
+	a.Mul(x, y, cap)
+	b.Mul(y, x, cap)
+	if a.Eq(&b) != 1 {
+		panic("Int.Mul: (x*y)!=(y*x)")
+	}
+
+	return 0
+}
+
+func FuzzIntNeg(data []byte) int {
+	var i Int
+	i.SetBytes(data)
+
+	yes := Choice(1)
+	i.Neg(yes)
+
+	no := Choice(0)
+	i.Neg(no)
+	return 0
+}
+
+func FuzzIntResize(data []byte) int {
+	if len(data) < 2 {
+		return -1
+	}
+
+	cap := int(data[0])
+
+	var i Int
+	i.SetBytes(data[1:])
+	i.Resize(cap)
+	return 0
+}
+
+// Check all methods of an Int that require no Int or Modulus as input
+func runAllInt(i *Int) {
+	i.Abs()
+	i.AnnouncedLen()
+	i.Big()
+	i.Clone()
+	i.IsNegative()
+	i.TrueLen()
+	i.String()
+
+	if _, err := i.MarshalBinary(); err != nil {
+		panic(err)
+	}
+
+	if i.Eq(i) != 1 {
+		panic("Int.Eq: i!=i")
+	}
+}
+
+// Convert a byte array into two Ints and one Modulus
+func getTwoInts(data []byte) (*Int, *Int, error) {
+	l := len(data)
+	if l < 3 {
+		return nil, nil, errors.New("too few bytes")
+	}
+
+	chunk := int(l / 3)
+	a := 0 + chunk
+	b := a + chunk
+
+	var x Int
+	var y Int
+	x.SetBytes(data[0 : a-1])
+	y.SetBytes(data[a : b-1])
+	return &x, &y, nil
+}
+
+// Convert a byte array into one Nat, one Int, and one Modulus
+func getOneIntAndOneNatAndOneMod(data []byte) (*Int, *Nat, *Modulus, error) {
+	l := len(data)
+	if l < 3 {
+		return nil, nil, nil, errors.New("too few bytes")
+	}
+
+	chunk := int(l / 3)
+	a := 0 + chunk
+	b := a + chunk
+	c := b + chunk
+
+	var i Int
+	i.SetBytes(data[0 : a-1])
+
+	var z Nat
+	z.SetBytes(data[a : b-1])
+
+	pBytes := data[b : c-1]
+	if isZero(pBytes) {
+		return nil, nil, nil, errors.New("modulus cannot be zero")
+	}
+	p := ModulusFromBytes(pBytes)
+
+	return &i, &z, p, nil
+}

--- a/num_fuzz.go
+++ b/num_fuzz.go
@@ -1,0 +1,569 @@
+// +build gofuzz
+
+package saferith
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/big"
+	"regexp"
+)
+
+var zeroHexRegExp = regexp.MustCompile("0(x0+)?")
+
+func FuzzNat(data []byte) int {
+	FuzzNatSetBig(data)
+	FuzzNatSetBytes(data)
+	FuzzNatSetHex(data)
+	FuzzNatSetNat(data)
+	FuzzNatSetUint64(data)
+	FuzzNatUnmarshalBinary(data)
+
+	FuzzNatArithmetic(data)
+	FuzzNatBitShifting(data)
+	FuzzNatCompare(data)
+	FuzzNatResize(data)
+	return 0
+}
+
+func FuzzModulus(data []byte) int {
+	FuzzModulusFromBytes(data)
+	FuzzModulusFromHex(data)
+	FuzzModulusFromNat(data)
+	FuzzModulusFromUint64(data)
+	FuzzModulusUnmarshalBinary(data)
+
+	FuzzModulesCompare(data)
+	return 0
+}
+
+func FuzzNatSetBig(data []byte) int {
+	var x big.Int
+	x.SetBytes(data)
+
+	l := len(data)
+	for i := 0; i < l; i++ {
+		var z Nat
+		z.SetBig(&x, i)
+		runNatFuncs(&z, l)
+	}
+
+	return 0
+}
+
+func FuzzNatSetBytes(data []byte) int {
+	var z Nat
+	z.SetBytes(data)
+	runNatFuncs(&z, len(data))
+	return 0
+}
+
+func FuzzNatSetHex(data []byte) int {
+	x := string(data)
+
+	var z Nat
+	z.SetHex(x)
+	runNatFuncs(&z, len(data))
+	return 0
+}
+
+func FuzzNatSetNat(data []byte) int {
+	var x Nat
+	x.SetBytes(data)
+
+	var z Nat
+	z.SetNat(&x)
+	runNatFuncs(&z, len(data))
+	return 0
+}
+
+func FuzzNatSetUint64(data []byte) int {
+	l := len(data)
+	if l != 8 {
+		return -1
+	}
+
+	x := binary.LittleEndian.Uint64(data)
+
+	var z Nat
+	z.SetUint64(x)
+	runNatFuncs(&z, l)
+	return 0
+}
+
+func FuzzNatUnmarshalBinary(data []byte) int {
+	var z Nat
+	if err := z.UnmarshalBinary(data); err != nil {
+		panic(err)
+	}
+
+	runNatFuncs(&z, len(data))
+	return 0
+}
+
+func FuzzNatArithmetic(data []byte) int {
+	FuzzNatUnaryArithmetic(data)
+	FuzzNatAdd(data)
+	FuzzNatSub(data)
+	FuzzNatMul(data)
+	FuzzNatDiv(data)
+	FuzzNatExp(data)
+	FuzzNatSqrt(data)
+	return 0
+}
+
+func FuzzNatUnaryArithmetic(data []byte) int {
+	x, p, err := getOneNatAndOneMod(data)
+	if err != nil {
+		return -1
+	}
+
+	var z Nat
+	z.Mod(x, p)
+	z.ModNeg(x, p)
+	z.ModInverse(x, p)
+	return 0
+}
+
+func FuzzNatAdd(data []byte) int {
+	if len(data) < 2 {
+		return -1
+	}
+
+	cap := int(data[0])
+	x, y, p, err := getTwoNatsAndOneMod(data[1:])
+	if err != nil {
+		return -1
+	}
+
+	var a Nat
+	var b Nat
+	a.ModAdd(x, y, p)
+	b.ModAdd(y, x, p)
+	if a.Eq(&b) != 1 {
+		panic("Nat.ModAdd: (x+y)!=(y+x)")
+	}
+
+	a.Add(x, y, cap)
+	b.Add(y, x, cap)
+	if a.Eq(&b) != 1 {
+		panic("Nat.Add: (x+y)!=(y+x)")
+	}
+
+	return 0
+}
+
+func FuzzNatSub(data []byte) int {
+	if len(data) < 2 {
+		return -1
+	}
+
+	cap := int(data[0])
+	x, y, p, err := getTwoNatsAndOneMod(data[1:])
+	if err != nil {
+		return -1
+	}
+
+	var z Nat
+	z.ModSub(x, y, p)
+	z.ModSub(y, x, p)
+	z.Sub(x, y, cap)
+	z.Sub(y, x, cap)
+	return 0
+}
+
+func FuzzNatMul(data []byte) int {
+	if len(data) < 2 {
+		return -1
+	}
+
+	cap := int(data[0])
+	x, y, p, err := getTwoNatsAndOneMod(data[1:])
+	if err != nil {
+		return -1
+	}
+
+	var a Nat
+	var b Nat
+	a.ModMul(x, y, p)
+	b.ModMul(y, x, p)
+	if a.Eq(&b) != 1 {
+		panic("Nat.ModMul: (x*y)!=(y*x)")
+	}
+
+	a.Mul(x, y, cap)
+	b.Mul(y, x, cap)
+	if a.Eq(&b) != 1 {
+		panic("Nat.Mul: (x*y)!=(y*x)")
+	}
+
+	return 0
+}
+
+func FuzzNatDiv(data []byte) int {
+	if len(data) < 2 {
+		return -1
+	}
+
+	cap := int(data[0])
+	x, p, err := getOneNatAndOneMod(data[1:])
+	if err != nil {
+		return -1
+	}
+
+	var z Nat
+	z.Div(x, p, cap)
+	return 0
+}
+
+func FuzzNatExp(data []byte) int {
+	x, y, p, err := getTwoNatsAndOneMod(data)
+	if err != nil {
+		return -1
+	}
+
+	var z Nat
+	z.Exp(x, y, p)
+	return 0
+}
+
+func FuzzNatSqrt(data []byte) int {
+	x, p, err := getOneNatAndOneMod(data)
+	if err != nil {
+		return -1
+	}
+
+	if p.nat.limbs[0]&1 == 0 {
+		return -1
+	}
+
+	var z Nat
+	z.ModSqrt(x, p)
+	return 0
+}
+
+func FuzzNatBitShifting(data []byte) int {
+	if len(data) < 3 {
+		return -1
+	}
+
+	shift := uint(data[0])
+	cap := int(data[1])
+
+	var x Nat
+	x.SetBytes(data[2:])
+
+	var z Nat
+	z.Rsh(&x, shift, cap)
+	z.Lsh(&x, shift, cap)
+	return 0
+}
+
+func FuzzNatIsUnit(data []byte) int {
+	z, p, err := getOneNatAndOneMod(data)
+	if err != nil {
+		return -1
+	}
+
+	z.IsUnit(p)
+	return 0
+}
+
+func FuzzNatCmp(data []byte) int {
+	x, y, _, err := getTwoNatsAndOneMod(data)
+	if err != nil {
+		return -1
+	}
+
+	gt1, eq1, lt1 := x.Cmp(y)
+	gt2, eq2, lt2 := y.Cmp(x)
+	if eq1 != eq2 {
+		panic("Nat.Cmp: (x==y)!=(y==x)")
+	}
+
+	if eq1 == 0 {
+		if gt1 == gt2 || lt1 == lt2 {
+			panic("Nat.Cmp: (x!=y), but !(x>y) or !(x<y)")
+		}
+	} else {
+		if gt1 != gt2 || lt1 != lt2 {
+			panic("Nat.Cmp: (x==y), but (x>y) or (x<y)")
+		}
+	}
+
+	return 0
+}
+
+func FuzzNatCmpMod(data []byte) int {
+	z, p, err := getOneNatAndOneMod(data)
+	if err != nil {
+		return -1
+	}
+
+	z.CmpMod(p)
+	return 0
+}
+
+func FuzzNatEq(data []byte) int {
+	x, y, _, err := getTwoNatsAndOneMod(data)
+	if err != nil {
+		return -1
+	}
+
+	eq1 := x.Eq(y)
+	eq2 := y.Eq(x)
+	if eq1 != eq2 {
+		panic("Nat.Eq: (x==y)!=(y==x)")
+	}
+
+	return 0
+}
+
+func FuzzNatCoprime(data []byte) int {
+	x, y, _, err := getTwoNatsAndOneMod(data)
+	if err != nil {
+		return -1
+	}
+
+	coprime1 := x.Coprime(y)
+	coprime2 := y.Coprime(x)
+	if coprime1 != coprime2 {
+		panic("Nat.Coprime: (x coprime y)!=(y coprime x)")
+	}
+
+	return 0
+}
+
+func FuzzNatCompare(data []byte) int {
+	FuzzNatIsUnit(data)
+	FuzzNatCmp(data)
+	FuzzNatCmpMod(data)
+	FuzzNatEq(data)
+	FuzzNatCoprime(data)
+	return 0
+}
+
+func FuzzNatResize(data []byte) int {
+	if len(data) < 2 {
+		return -1
+	}
+
+	cap := int(data[0])
+
+	var z Nat
+	z.SetBytes(data[1:])
+	z.Resize(cap)
+	return 0
+}
+
+func FuzzModulusFromBytes(data []byte) int {
+	if isZero(data) {
+		return -1
+	}
+
+	p := ModulusFromBytes(data)
+	runModulusFuncs(p)
+	return 0
+}
+
+func FuzzModulusFromHex(data []byte) int {
+	if isZero(data) {
+		return -1
+	}
+
+	x := string(data)
+	if p, err := ModulusFromHex(x); err == nil {
+		runModulusFuncs(p)
+	}
+
+	return 0
+}
+
+func FuzzModulusFromNat(data []byte) int {
+	if isZero(data) {
+		return -1
+	}
+
+	var z Nat
+	z.SetBytes(data)
+	p := ModulusFromNat(&z)
+	runModulusFuncs(p)
+	return 0
+}
+
+func FuzzModulusFromUint64(data []byte) int {
+	if len(data) != 8 || isZero(data) {
+		return -1
+	}
+
+	x := binary.LittleEndian.Uint64(data)
+	p := ModulusFromUint64(x)
+	runModulusFuncs(p)
+	return 0
+}
+
+func FuzzModulusUnmarshalBinary(data []byte) int {
+	if isZero(data) {
+		return -1
+	}
+
+	var p Modulus
+	if err := p.UnmarshalBinary(data); err != nil {
+		panic(err)
+	}
+
+	runModulusFuncs(&p)
+	return 0
+}
+
+func FuzzModulesCompare(data []byte) int {
+	l := len(data)
+	if l < 2 {
+		return -1
+	}
+
+	chunkSize := int(l / 2)
+	p := ModulusFromBytes(data[0 : chunkSize-1])
+	q := ModulusFromBytes(data[chunkSize:])
+
+	gt1, eq1, lt1 := p.Cmp(q)
+	gt2, eq2, lt2 := q.Cmp(p)
+	if eq1 != eq2 {
+		panic("Modulus.Cmp: (p==q)!=(q==p)")
+	}
+
+	if eq1 == 0 {
+		if gt1 == gt2 || lt1 == lt2 {
+			panic("Modules.Cmp: (p!=q), but !(p>q) or !(p<q)")
+		}
+	} else {
+		if gt1 != gt2 || lt1 != lt2 {
+			panic("Modules.Cmp: (p==q), but (p>q) or (p<q)")
+		}
+	}
+
+	return 0
+}
+
+// Run methods of a Nat that require no Nat or Modulus as input
+func runNatFuncs(z *Nat, l int) {
+	z.AnnouncedLen()
+	z.Big()
+	z.Bytes()
+	z.Clone()
+	z.EqZero()
+	z.Hex()
+	z.String()
+	z.TrueLen()
+	z.Uint64()
+
+	if _, err := z.MarshalBinary(); err != nil {
+		panic(err)
+	}
+
+	if z.Eq(z) != 1 {
+		panic("Nat.Eq: z!=z")
+	}
+
+	gt, eq, lt := z.Cmp(z)
+	if gt != 0 || eq != 1 || lt != 0 {
+		panic(fmt.Sprintf("Nat.Cmp: z!=z, gt=%b,eq=%b,lt=%b", gt, eq, lt))
+	}
+
+	for i := 0; i < l; i++ {
+		z.Byte(i)
+	}
+
+	buf := make([]byte, l)
+	z.FillBytes(buf)
+}
+
+// Run methods of a Modulus that require no Nat or Modulus as input
+func runModulusFuncs(p *Modulus) {
+	p.Big()
+	p.BitLen()
+	p.Bytes()
+	p.Hex()
+	p.Nat()
+	p.String()
+
+	if _, err := p.MarshalBinary(); err != nil {
+		panic(err)
+	}
+
+	gt, eq, lt := p.Cmp(p)
+	if gt != 0 || eq != 1 || lt != 0 {
+		panic(fmt.Sprintf("Modulus.Cmp: p!=p, gt=%b,eq=%b,lt=%b", gt, eq, lt))
+	}
+}
+
+// Convert a byte array into two Nats and one Modulus
+func getTwoNatsAndOneMod(data []byte) (*Nat, *Nat, *Modulus, error) {
+	l := len(data)
+	if l < 3 {
+		return nil, nil, nil, errors.New("too few bytes")
+	}
+
+	chunkSize := int(l / 3)
+	a := 0 + chunkSize
+	b := a + chunkSize
+	c := b + chunkSize
+
+	var x Nat
+	var y Nat
+	x.SetBytes(data[0 : a-1])
+	y.SetBytes(data[a : b-1])
+
+	pBytes := data[b : c-1]
+	if isZero(pBytes) {
+		return nil, nil, nil, errors.New("modulus cannot be zero")
+	}
+	p := ModulusFromBytes(pBytes)
+
+	return &x, &y, p, nil
+}
+
+// Convert a byte array into one Nat and one Modulus
+func getOneNatAndOneMod(data []byte) (*Nat, *Modulus, error) {
+	l := len(data)
+	if l < 2 {
+		return nil, nil, errors.New("too few bytes")
+	}
+
+	chunkSize := int(l / 2)
+	a := 0 + chunkSize
+	b := a + chunkSize
+
+	var z Nat
+	z.SetBytes(data[0 : a-1])
+
+	pBytes := data[a : b-1]
+	if isZero(pBytes) {
+		return nil, nil, errors.New("modulus cannot be zero")
+	}
+	p := ModulusFromBytes(pBytes)
+
+	return &z, p, nil
+}
+
+// Check if a byte array is all zeros
+func isZero(data []byte) bool {
+	if len(data) == 0 {
+		return true
+	}
+
+	s := string(data)
+	if zeroHexRegExp.MatchString(s) {
+		return true
+	}
+
+	// if data != 0x00... return false
+	for _, b := range data {
+		if b != 0x0 {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
This adds the fuzzing code that resulted in d39f5a274f7c3b8c8d60456b1525cce26ffacfe7. These fuzz functions are written for [dvyukov/go-fuzz](https://github.com/dvyukov/go-fuzz).

All-in-all it's quite extensive and perhaps it fuzzes some stuff that may seem to trivial to fuzz. I'd be happy to remove parts of it if that's preferred and I also welcome any suggestions for how to improve the tests.

I put it together such that you can run these commands:

```
# get go-fuzz
$ go get -u github.com/dvyukov/go-fuzz/go-fuzz@latest github.com/dvyukov/go-fuzz/go-fuzz-build@latest

# build fuzz binary
$ go-fuzz-build

# run fuzzer on Nat
$ go-fuzz -workdir ./_fuzz_nat -func FuzzNat

# or run fuzzer on Int
$ go-fuzz -workdir ./_fuzz_int -func FuzzInt
```

to fuzz everything. Or run something more specific, e.g.:

```
# run fuzzer on Nat.ModSqrt
$ go-fuzz -workdir ./_fuzz_nat -func FuzzNatSqrt
```

to fuzz a specific (set of) function(s). The former is easier to use (just one run to fuzz everything) while the latter can be more efficient (because coverage guiding can do its job better and non-zero return values can be used).