### PR TITLE
Add support for all assembly architectures

### DIFF
--- a/arith.go
+++ b/arith.go
@@ -42,6 +42,12 @@ const (
 //
 // These operations are used by the vector operations below.
 
+// z1<<_W + z0 = x*y
+func mulWW_g(x, y Word) (z1, z0 Word) {
+	hi, lo := bits.Mul(uint(x), uint(y))
+	return Word(hi), Word(lo)
+}
+
 // z1<<_W + z0 = x*y + c
 func mulAddWWW_g(x, y, c Word) (z1, z0 Word) {
 	hi, lo := bits.Mul(uint(x), uint(y))

--- a/arith_386.s
+++ b/arith_386.s
@@ -1,13 +1,23 @@
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in the LICENSE_go file.
 
+//go:build !math_big_pure_go
 // +build !math_big_pure_go
 
 #include "textflag.h"
 
 // This file provides fast assembly versions for the elementary
 // arithmetic operations on vectors implemented in arith.go.
+
+// func mulWW(x, y Word) (z1, z0 Word)
+TEXT ·mulWW(SB),NOSPLIT,$0
+	MOVL x+0(FP), AX
+	MULL y+4(FP)
+	MOVL DX, z1+8(FP)
+	MOVL AX, z0+12(FP)
+	RET
+
 
 // func addVV(z, x, y []Word) (c Word)
 TEXT ·addVV(SB),NOSPLIT,$0
@@ -176,6 +186,34 @@ X9a:	SHRL CX, AX		// w1>>s
 X9b:	MOVL $0, c+28(FP)
 	RET
 
+
+// func mulAddVWW(z, x []Word, y, r Word) (c Word)
+TEXT ·mulAddVWW(SB),NOSPLIT,$0
+	MOVL z+0(FP), DI
+	MOVL x+12(FP), SI
+	MOVL y+24(FP), BP
+	MOVL r+28(FP), CX	// c = r
+	MOVL z_len+4(FP), BX
+	LEAL (DI)(BX*4), DI
+	LEAL (SI)(BX*4), SI
+	NEGL BX			// i = -n
+	JMP E5
+
+L5:	MOVL (SI)(BX*4), AX
+	MULL BP
+	ADDL CX, AX
+	ADCL $0, DX
+	MOVL AX, (DI)(BX*4)
+	MOVL DX, CX
+	ADDL $1, BX		// i++
+
+E5:	CMPL BX, $0		// i < 0
+	JL L5
+
+	MOVL CX, c+32(FP)
+	RET
+
+
 // func addMulVVW(z, x []Word, y Word) (c Word)
 TEXT ·addMulVVW(SB),NOSPLIT,$0
 	MOVL z+0(FP), DI
@@ -202,6 +240,3 @@ E6:	CMPL BX, $0		// i < 0
 
 	MOVL CX, c+28(FP)
 	RET
-
-
-

--- a/arith_arm.s
+++ b/arith_arm.s
@@ -1,7 +1,8 @@
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in the LICENSE_go file.
 
+//go:build !math_big_pure_go
 // +build !math_big_pure_go
 
 #include "textflag.h"
@@ -215,6 +216,33 @@ X6:
 	RET
 
 
+// func mulAddVWW(z, x []Word, y, r Word) (c Word)
+TEXT ·mulAddVWW(SB),NOSPLIT,$0
+	MOVW	$0, R0
+	MOVW	z+0(FP), R1
+	MOVW	z_len+4(FP), R5
+	MOVW	x+12(FP), R2
+	MOVW	y+24(FP), R3
+	MOVW	r+28(FP), R4
+	ADD	R5<<2, R1, R5
+	B E8
+
+	// word loop
+L8:
+	MOVW.P	4(R2), R6
+	MULLU	R6, R3, (R7, R6)
+	ADD.S	R4, R6
+	ADC	R0, R7
+	MOVW.P	R6, 4(R1)
+	MOVW	R7, R4
+E8:
+	TEQ	R1, R5
+	BNE	L8
+
+	MOVW	R4, c+32(FP)
+	RET
+
+
 // func addMulVVW(z, x []Word, y Word) (c Word)
 TEXT ·addMulVVW(SB),NOSPLIT,$0
 	MOVW	$0, R0
@@ -244,3 +272,13 @@ E9:
 	MOVW	R4, c+28(FP)
 	RET
 
+
+
+// func mulWW(x, y Word) (z1, z0 Word)
+TEXT ·mulWW(SB),NOSPLIT,$0
+	MOVW	x+0(FP), R1
+	MOVW	y+4(FP), R2
+	MULLU	R1, R2, (R4, R3)
+	MOVW	R4, z1+8(FP)
+	MOVW	R3, z0+12(FP)
+	RET

--- a/arith_arm64.s
+++ b/arith_arm64.s
@@ -1,7 +1,8 @@
 // Copyright 2013 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in the LICENSE_go file.
 
+//go:build !math_big_pure_go
 // +build !math_big_pure_go
 
 #include "textflag.h"
@@ -11,6 +12,17 @@
 
 // TODO: Consider re-implementing using Advanced SIMD
 // once the assembler supports those instructions.
+
+// func mulWW(x, y Word) (z1, z0 Word)
+TEXT ·mulWW(SB),NOSPLIT,$0
+	MOVD	x+0(FP), R0
+	MOVD	y+8(FP), R1
+	MUL	R0, R1, R2
+	UMULH	R0, R1, R3
+	MOVD	R3, z1+16(FP)
+	MOVD	R2, z0+24(FP)
+	RET
+
 
 // func addVV(z, x, y []Word) (c Word)
 TEXT ·addVV(SB),NOSPLIT,$0
@@ -394,6 +406,64 @@ cloop:
 	B	cloop
 len0:
 	MOVD	$0, c+56(FP)
+	RET
+
+
+// func mulAddVWW(z, x []Word, y, r Word) (c Word)
+TEXT ·mulAddVWW(SB),NOSPLIT,$0
+	MOVD	z+0(FP), R1
+	MOVD	z_len+8(FP), R0
+	MOVD	x+24(FP), R2
+	MOVD	y+48(FP), R3
+	MOVD	r+56(FP), R4
+	// c, z = x * y + r
+	TBZ	$0, R0, two
+	MOVD.P	8(R2), R5
+	MUL	R3, R5, R7
+	UMULH	R3, R5, R8
+	ADDS	R4, R7
+	ADC	$0, R8, R4	// c, z[i] = x[i] * y +  r
+	MOVD.P	R7, 8(R1)
+	SUB	$1, R0
+two:
+	TBZ	$1, R0, loop
+	LDP.P	16(R2), (R5, R6)
+	MUL	R3, R5, R10
+	UMULH	R3, R5, R11
+	ADDS	R4, R10
+	MUL	R3, R6, R12
+	UMULH	R3, R6, R13
+	ADCS	R12, R11
+	ADC	$0, R13, R4
+
+	STP.P	(R10, R11), 16(R1)
+	SUB	$2, R0
+loop:
+	CBZ	R0, done
+	LDP.P	32(R2), (R5, R6)
+	LDP	-16(R2), (R7, R8)
+
+	MUL	R3, R5, R10
+	UMULH	R3, R5, R11
+	ADDS	R4, R10
+	MUL	R3, R6, R12
+	UMULH	R3, R6, R13
+	ADCS	R11, R12
+
+	MUL	R3, R7, R14
+	UMULH	R3, R7, R15
+	ADCS	R13, R14
+	MUL	R3, R8, R16
+	UMULH	R3, R8, R17
+	ADCS	R15, R16
+	ADC	$0, R17, R4
+
+	STP.P	(R10, R12), 32(R1)
+	STP	(R14, R16), -16(R1)
+	SUB	$4, R0
+	B	loop
+done:
+	MOVD	R4, c+64(FP)
 	RET
 
 

--- a/arith_decl.go
+++ b/arith_decl.go
@@ -2,15 +2,18 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE_go file.
 
+//go:build !math_big_pure_go
 // +build !math_big_pure_go
 
 package saferith
 
 // implemented in arith_$GOARCH.s
+func mulWW(x, y Word) (z1, z0 Word)
 func addVV(z, x, y []Word) (c Word)
 func subVV(z, x, y []Word) (c Word)
 func addVW(z, x []Word, y Word) (c Word)
 func subVW(z, x []Word, y Word) (c Word)
 func shlVU(z, x []Word, s uint) (c Word)
 func shrVU(z, x []Word, s uint) (c Word)
+func mulAddVWW(z, x []Word, y, r Word) (c Word)
 func addMulVVW(z, x []Word, y Word) (c Word)

--- a/arith_decl_pure.go
+++ b/arith_decl_pure.go
@@ -2,9 +2,14 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE_go file.
 
+//go:build math_big_pure_go
 // +build math_big_pure_go
 
 package saferith
+
+func mulWW(x, y Word) (z1, z0 Word) {
+	return mulWW_g(x, y)
+}
 
 func addVV(z, x, y []Word) (c Word) {
 	return addVV_g(z, x, y)

--- a/arith_decl_s390x.go
+++ b/arith_decl_s390x.go
@@ -1,0 +1,18 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE_go file.
+
+//go:build !math_big_pure_go
+// +build !math_big_pure_go
+
+package saferith
+
+func addVV_check(z, x, y []Word) (c Word)
+func addVV_vec(z, x, y []Word) (c Word)
+func addVV_novec(z, x, y []Word) (c Word)
+func subVV_check(z, x, y []Word) (c Word)
+func subVV_vec(z, x, y []Word) (c Word)
+func subVV_novec(z, x, y []Word) (c Word)
+
+// This should be feature detected, but we can't use the internal/cpu package
+var hasVX = false

--- a/arith_mips64x.s
+++ b/arith_mips64x.s
@@ -1,0 +1,39 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE_go file.
+
+//go:build !math_big_pure_go && (mips64 || mips64le)
+// +build !math_big_pure_go
+// +build mips64 mips64le
+
+#include "textflag.h"
+
+// This file provides fast assembly versions for the elementary
+// arithmetic operations on vectors implemented in arith.go.
+
+TEXT ·mulWW(SB),NOSPLIT,$0
+	JMP ·mulWW_g(SB)
+
+TEXT ·addVV(SB),NOSPLIT,$0
+	JMP ·addVV_g(SB)
+
+TEXT ·subVV(SB),NOSPLIT,$0
+	JMP ·subVV_g(SB)
+
+TEXT ·addVW(SB),NOSPLIT,$0
+	JMP ·addVW_g(SB)
+
+TEXT ·subVW(SB),NOSPLIT,$0
+	JMP ·subVW_g(SB)
+
+TEXT ·shlVU(SB),NOSPLIT,$0
+	JMP ·shlVU_g(SB)
+
+TEXT ·shrVU(SB),NOSPLIT,$0
+	JMP ·shrVU_g(SB)
+
+TEXT ·mulAddVWW(SB),NOSPLIT,$0
+	JMP ·mulAddVWW_g(SB)
+
+TEXT ·addMulVVW(SB),NOSPLIT,$0
+	JMP ·addMulVVW_g(SB)

--- a/arith_mipsx.s
+++ b/arith_mipsx.s
@@ -1,0 +1,39 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE_go file.
+
+//go:build !math_big_pure_go && (mips || mipsle)
+// +build !math_big_pure_go
+// +build mips mipsle
+
+#include "textflag.h"
+
+// This file provides fast assembly versions for the elementary
+// arithmetic operations on vectors implemented in arith.go.
+
+TEXT ·mulWW(SB),NOSPLIT,$0
+	JMP	·mulWW_g(SB)
+
+TEXT ·addVV(SB),NOSPLIT,$0
+	JMP	·addVV_g(SB)
+
+TEXT ·subVV(SB),NOSPLIT,$0
+	JMP	·subVV_g(SB)
+
+TEXT ·addVW(SB),NOSPLIT,$0
+	JMP	·addVW_g(SB)
+
+TEXT ·subVW(SB),NOSPLIT,$0
+	JMP	·subVW_g(SB)
+
+TEXT ·shlVU(SB),NOSPLIT,$0
+	JMP	·shlVU_g(SB)
+
+TEXT ·shrVU(SB),NOSPLIT,$0
+	JMP	·shrVU_g(SB)
+
+TEXT ·mulAddVWW(SB),NOSPLIT,$0
+	JMP	·mulAddVWW_g(SB)
+
+TEXT ·addMulVVW(SB),NOSPLIT,$0
+	JMP	·addMulVVW_g(SB)

--- a/arith_ppc64x.s
+++ b/arith_ppc64x.s
@@ -1,0 +1,481 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE_go file.
+
+//go:build !math_big_pure_go && (ppc64 || ppc64le)
+// +build !math_big_pure_go
+// +build ppc64 ppc64le
+
+#include "textflag.h"
+
+// This file provides fast assembly versions for the elementary
+// arithmetic operations on vectors implemented in arith.go.
+
+// func mulWW(x, y Word) (z1, z0 Word)
+TEXT ·mulWW(SB), NOSPLIT, $0
+	MOVD   x+0(FP), R4
+	MOVD   y+8(FP), R5
+	MULHDU R4, R5, R6
+	MULLD  R4, R5, R7
+	MOVD   R6, z1+16(FP)
+	MOVD   R7, z0+24(FP)
+	RET
+
+// func addVV(z, y, y []Word) (c Word)
+// z[i] = x[i] + y[i] for all i, carrying
+TEXT ·addVV(SB), NOSPLIT, $0
+	MOVD  z_len+8(FP), R7   // R7 = z_len
+	MOVD  x+24(FP), R8      // R8 = x[]
+	MOVD  y+48(FP), R9      // R9 = y[]
+	MOVD  z+0(FP), R10      // R10 = z[]
+
+	// If z_len = 0, we are done
+	CMP   R0, R7
+	MOVD  R0, R4
+	BEQ   done
+
+	// Process the first iteration out of the loop so we can
+	// use MOVDU and avoid 3 index registers updates.
+	MOVD  0(R8), R11      // R11 = x[i]
+	MOVD  0(R9), R12      // R12 = y[i]
+	ADD   $-1, R7         // R7 = z_len - 1
+	ADDC  R12, R11, R15   // R15 = x[i] + y[i], set CA
+	CMP   R0, R7
+	MOVD  R15, 0(R10)     // z[i]
+	BEQ   final          // If z_len was 1, we are done
+
+	SRD   $2, R7, R5      // R5 = z_len/4
+	CMP   R0, R5
+	MOVD  R5, CTR         // Set up loop counter
+	BEQ   tail            // If R5 = 0, we can't use the loop
+
+	// Process 4 elements per iteration. Unrolling this loop
+	// means a performance trade-off: we will lose performance
+	// for small values of z_len (0.90x in the worst case), but
+	// gain significant performance as z_len increases (up to
+	// 1.45x).
+loop:
+	MOVD  8(R8), R11      // R11 = x[i]
+	MOVD  16(R8), R12     // R12 = x[i+1]
+	MOVD  24(R8), R14     // R14 = x[i+2]
+	MOVDU 32(R8), R15     // R15 = x[i+3]
+	MOVD  8(R9), R16      // R16 = y[i]
+	MOVD  16(R9), R17     // R17 = y[i+1]
+	MOVD  24(R9), R18     // R18 = y[i+2]
+	MOVDU 32(R9), R19     // R19 = y[i+3]
+	ADDE  R11, R16, R20   // R20 = x[i] + y[i] + CA
+	ADDE  R12, R17, R21   // R21 = x[i+1] + y[i+1] + CA
+	ADDE  R14, R18, R22   // R22 = x[i+2] + y[i+2] + CA
+	ADDE  R15, R19, R23   // R23 = x[i+3] + y[i+3] + CA
+	MOVD  R20, 8(R10)     // z[i]
+	MOVD  R21, 16(R10)    // z[i+1]
+	MOVD  R22, 24(R10)    // z[i+2]
+	MOVDU R23, 32(R10)    // z[i+3]
+	ADD   $-4, R7         // R7 = z_len - 4
+	BC  16, 0, loop       // bdnz
+
+	// We may have more elements to read
+	CMP   R0, R7
+	BEQ   final
+
+	// Process the remaining elements, one at a time
+tail:
+	MOVDU 8(R8), R11      // R11 = x[i]
+	MOVDU 8(R9), R16      // R16 = y[i]
+	ADD   $-1, R7         // R7 = z_len - 1
+	ADDE  R11, R16, R20   // R20 = x[i] + y[i] + CA
+	CMP   R0, R7
+	MOVDU R20, 8(R10)     // z[i]
+	BEQ   final           // If R7 = 0, we are done
+
+	MOVDU 8(R8), R11
+	MOVDU 8(R9), R16
+	ADD   $-1, R7
+	ADDE  R11, R16, R20
+	CMP   R0, R7
+	MOVDU R20, 8(R10)
+	BEQ   final
+
+	MOVD  8(R8), R11
+	MOVD  8(R9), R16
+	ADDE  R11, R16, R20
+	MOVD  R20, 8(R10)
+
+final:
+	ADDZE R4              // Capture CA
+
+done:
+	MOVD  R4, c+72(FP)
+	RET
+
+// func subVV(z, x, y []Word) (c Word)
+// z[i] = x[i] - y[i] for all i, carrying
+TEXT ·subVV(SB), NOSPLIT, $0
+	MOVD  z_len+8(FP), R7 // R7 = z_len
+	MOVD  x+24(FP), R8    // R8 = x[]
+	MOVD  y+48(FP), R9    // R9 = y[]
+	MOVD  z+0(FP), R10    // R10 = z[]
+
+	// If z_len = 0, we are done
+	CMP   R0, R7
+	MOVD  R0, R4
+	BEQ   done
+
+	// Process the first iteration out of the loop so we can
+	// use MOVDU and avoid 3 index registers updates.
+	MOVD  0(R8), R11      // R11 = x[i]
+	MOVD  0(R9), R12      // R12 = y[i]
+	ADD   $-1, R7         // R7 = z_len - 1
+	SUBC  R12, R11, R15   // R15 = x[i] - y[i], set CA
+	CMP   R0, R7
+	MOVD  R15, 0(R10)     // z[i]
+	BEQ   final           // If z_len was 1, we are done
+
+	SRD   $2, R7, R5      // R5 = z_len/4
+	CMP   R0, R5
+	MOVD  R5, CTR         // Set up loop counter
+	BEQ   tail            // If R5 = 0, we can't use the loop
+
+	// Process 4 elements per iteration. Unrolling this loop
+	// means a performance trade-off: we will lose performance
+	// for small values of z_len (0.92x in the worst case), but
+	// gain significant performance as z_len increases (up to
+	// 1.45x).
+loop:
+	MOVD  8(R8), R11      // R11 = x[i]
+	MOVD  16(R8), R12     // R12 = x[i+1]
+	MOVD  24(R8), R14     // R14 = x[i+2]
+	MOVDU 32(R8), R15     // R15 = x[i+3]
+	MOVD  8(R9), R16      // R16 = y[i]
+	MOVD  16(R9), R17     // R17 = y[i+1]
+	MOVD  24(R9), R18     // R18 = y[i+2]
+	MOVDU 32(R9), R19     // R19 = y[i+3]
+	SUBE  R16, R11, R20   // R20 = x[i] - y[i] + CA
+	SUBE  R17, R12, R21   // R21 = x[i+1] - y[i+1] + CA
+	SUBE  R18, R14, R22   // R22 = x[i+2] - y[i+2] + CA
+	SUBE  R19, R15, R23   // R23 = x[i+3] - y[i+3] + CA
+	MOVD  R20, 8(R10)     // z[i]
+	MOVD  R21, 16(R10)    // z[i+1]
+	MOVD  R22, 24(R10)    // z[i+2]
+	MOVDU R23, 32(R10)    // z[i+3]
+	ADD   $-4, R7         // R7 = z_len - 4
+	BC  16, 0, loop       // bdnz
+
+	// We may have more elements to read
+	CMP   R0, R7
+	BEQ   final
+
+	// Process the remaining elements, one at a time
+tail:
+	MOVDU 8(R8), R11      // R11 = x[i]
+	MOVDU 8(R9), R16      // R16 = y[i]
+	ADD   $-1, R7         // R7 = z_len - 1
+	SUBE  R16, R11, R20   // R20 = x[i] - y[i] + CA
+	CMP   R0, R7
+	MOVDU R20, 8(R10)     // z[i]
+	BEQ   final           // If R7 = 0, we are done
+
+	MOVDU 8(R8), R11
+	MOVDU 8(R9), R16
+	ADD   $-1, R7
+	SUBE  R16, R11, R20
+	CMP   R0, R7
+	MOVDU R20, 8(R10)
+	BEQ   final
+
+	MOVD  8(R8), R11
+	MOVD  8(R9), R16
+	SUBE  R16, R11, R20
+	MOVD  R20, 8(R10)
+
+final:
+	ADDZE R4
+	XOR   $1, R4
+
+done:
+	MOVD  R4, c+72(FP)
+	RET
+
+// func addVW(z, x []Word, y Word) (c Word)
+TEXT ·addVW(SB), NOSPLIT, $0
+	MOVD z+0(FP), R10	// R10 = z[]
+	MOVD x+24(FP), R8	// R8 = x[]
+	MOVD y+48(FP), R4	// R4 = y = c
+	MOVD z_len+8(FP), R11	// R11 = z_len
+
+	CMP   R0, R11		// If z_len is zero, return
+	BEQ   done
+
+	// We will process the first iteration out of the loop so we capture
+	// the value of c. In the subsequent iterations, we will rely on the
+	// value of CA set here.
+	MOVD  0(R8), R20	// R20 = x[i]
+	ADD   $-1, R11		// R11 = z_len - 1
+	ADDC  R20, R4, R6	// R6 = x[i] + c
+	CMP   R0, R11		// If z_len was 1, we are done
+	MOVD  R6, 0(R10)	// z[i]
+	BEQ   final
+
+	// We will read 4 elements per iteration
+	SRD   $2, R11, R9	// R9 = z_len/4
+	DCBT  (R8)
+	CMP   R0, R9
+	MOVD  R9, CTR		// Set up the loop counter
+	BEQ   tail		// If R9 = 0, we can't use the loop
+
+loop:
+	MOVD  8(R8), R20	// R20 = x[i]
+	MOVD  16(R8), R21	// R21 = x[i+1]
+	MOVD  24(R8), R22	// R22 = x[i+2]
+	MOVDU 32(R8), R23	// R23 = x[i+3]
+	ADDZE R20, R24		// R24 = x[i] + CA
+	ADDZE R21, R25		// R25 = x[i+1] + CA
+	ADDZE R22, R26		// R26 = x[i+2] + CA
+	ADDZE R23, R27		// R27 = x[i+3] + CA
+	MOVD  R24, 8(R10)	// z[i]
+	MOVD  R25, 16(R10)	// z[i+1]
+	MOVD  R26, 24(R10)	// z[i+2]
+	MOVDU R27, 32(R10)	// z[i+3]
+	ADD   $-4, R11		// R11 = z_len - 4
+	BC    16, 0, loop	// bdnz
+
+	// We may have some elements to read
+	CMP R0, R11
+	BEQ final
+
+tail:
+	MOVDU 8(R8), R20
+	ADDZE R20, R24
+	ADD $-1, R11
+	MOVDU R24, 8(R10)
+	CMP R0, R11
+	BEQ final
+
+	MOVDU 8(R8), R20
+	ADDZE R20, R24
+	ADD $-1, R11
+	MOVDU R24, 8(R10)
+	CMP R0, R11
+	BEQ final
+
+	MOVD 8(R8), R20
+	ADDZE R20, R24
+	MOVD R24, 8(R10)
+
+final:
+	ADDZE R0, R4		// c = CA
+done:
+	MOVD  R4, c+56(FP)
+	RET
+
+// func subVW(z, x []Word, y Word) (c Word)
+TEXT ·subVW(SB), NOSPLIT, $0
+	MOVD  z+0(FP), R10	// R10 = z[]
+	MOVD  x+24(FP), R8	// R8 = x[]
+	MOVD  y+48(FP), R4	// R4 = y = c
+	MOVD  z_len+8(FP), R11	// R11 = z_len
+
+	CMP   R0, R11		// If z_len is zero, return
+	BEQ   done
+
+	// We will process the first iteration out of the loop so we capture
+	// the value of c. In the subsequent iterations, we will rely on the
+	// value of CA set here.
+	MOVD  0(R8), R20	// R20 = x[i]
+	ADD   $-1, R11		// R11 = z_len - 1
+	SUBC  R4, R20, R6	// R6 = x[i] - c
+	CMP   R0, R11		// If z_len was 1, we are done
+	MOVD  R6, 0(R10)	// z[i]
+	BEQ   final
+
+	// We will read 4 elements per iteration
+	SRD   $2, R11, R9	// R9 = z_len/4
+	DCBT  (R8)
+	CMP   R0, R9
+	MOVD  R9, CTR		// Set up the loop counter
+	BEQ   tail		// If R9 = 0, we can't use the loop
+
+	// The loop here is almost the same as the one used in s390x, but
+	// we don't need to capture CA every iteration because we've already
+	// done that above.
+loop:
+	MOVD  8(R8), R20
+	MOVD  16(R8), R21
+	MOVD  24(R8), R22
+	MOVDU 32(R8), R23
+	SUBE  R0, R20
+	SUBE  R0, R21
+	SUBE  R0, R22
+	SUBE  R0, R23
+	MOVD  R20, 8(R10)
+	MOVD  R21, 16(R10)
+	MOVD  R22, 24(R10)
+	MOVDU R23, 32(R10)
+	ADD   $-4, R11
+	BC    16, 0, loop	// bdnz
+
+	// We may have some elements to read
+	CMP   R0, R11
+	BEQ   final
+
+tail:
+	MOVDU 8(R8), R20
+	SUBE  R0, R20
+	ADD   $-1, R11
+	MOVDU R20, 8(R10)
+	CMP   R0, R11
+	BEQ   final
+
+	MOVDU 8(R8), R20
+	SUBE  R0, R20
+	ADD   $-1, R11
+	MOVDU R20, 8(R10)
+	CMP   R0, R11
+	BEQ   final
+
+	MOVD  8(R8), R20
+	SUBE  R0, R20
+	MOVD  R20, 8(R10)
+
+final:
+	// Capture CA
+	SUBE  R4, R4
+	NEG   R4, R4
+
+done:
+	MOVD  R4, c+56(FP)
+	RET
+
+TEXT ·shlVU(SB), NOSPLIT, $0
+	BR ·shlVU_g(SB)
+
+TEXT ·shrVU(SB), NOSPLIT, $0
+	BR ·shrVU_g(SB)
+
+// func mulAddVWW(z, x []Word, y, r Word) (c Word)
+TEXT ·mulAddVWW(SB), NOSPLIT, $0
+	MOVD    z+0(FP), R10      // R10 = z[]
+	MOVD    x+24(FP), R8      // R8 = x[]
+	MOVD    y+48(FP), R9      // R9 = y
+	MOVD    r+56(FP), R4      // R4 = r = c
+	MOVD    z_len+8(FP), R11  // R11 = z_len
+
+	CMP     R0, R11
+	BEQ     done
+
+	MOVD    0(R8), R20
+	ADD     $-1, R11
+	MULLD   R9, R20, R6       // R6 = z0 = Low-order(x[i]*y)
+	MULHDU  R9, R20, R7       // R7 = z1 = High-order(x[i]*y)
+	ADDC    R4, R6            // R6 = z0 + r
+	ADDZE   R7                // R7 = z1 + CA
+	CMP     R0, R11
+	MOVD    R7, R4            // R4 = c
+	MOVD    R6, 0(R10)        // z[i]
+	BEQ     done
+
+	// We will read 4 elements per iteration
+	SRD     $2, R11, R14      // R14 = z_len/4
+	DCBT    (R8)
+	CMP     R0, R14
+	MOVD    R14, CTR          // Set up the loop counter
+	BEQ     tail              // If R9 = 0, we can't use the loop
+
+loop:
+	MOVD    8(R8), R20        // R20 = x[i]
+	MOVD    16(R8), R21       // R21 = x[i+1]
+	MOVD    24(R8), R22       // R22 = x[i+2]
+	MOVDU   32(R8), R23       // R23 = x[i+3]
+	MULLD   R9, R20, R24      // R24 = z0[i]
+	MULHDU  R9, R20, R20      // R20 = z1[i]
+	ADDC    R4, R24           // R24 = z0[i] + c
+	ADDZE   R20               // R7 = z1[i] + CA
+	MULLD   R9, R21, R25
+	MULHDU  R9, R21, R21
+	ADDC    R20, R25
+	ADDZE   R21
+	MULLD   R9, R22, R26
+	MULHDU  R9, R22, R22
+	MULLD   R9, R23, R27
+	MULHDU  R9, R23, R23
+	ADDC    R21, R26
+	ADDZE   R22
+	MOVD    R24, 8(R10)       // z[i]
+	MOVD    R25, 16(R10)      // z[i+1]
+	ADDC    R22, R27
+	ADDZE   R23,R4		  // update carry
+	MOVD    R26, 24(R10)      // z[i+2]
+	MOVDU   R27, 32(R10)      // z[i+3]
+	ADD     $-4, R11          // R11 = z_len - 4
+	BC      16, 0, loop       // bdnz
+
+	// We may have some elements to read
+	CMP   R0, R11
+	BEQ   done
+
+	// Process the remaining elements, one at a time
+tail:
+	MOVDU   8(R8), R20        // R20 = x[i]
+	MULLD   R9, R20, R24      // R24 = z0[i]
+	MULHDU  R9, R20, R25      // R25 = z1[i]
+	ADD     $-1, R11          // R11 = z_len - 1
+	ADDC    R4, R24
+	ADDZE   R25
+	MOVDU   R24, 8(R10)       // z[i]
+	CMP     R0, R11
+	MOVD    R25, R4           // R4 = c
+	BEQ     done              // If R11 = 0, we are done
+
+	MOVDU   8(R8), R20
+	MULLD   R9, R20, R24
+	MULHDU  R9, R20, R25
+	ADD     $-1, R11
+	ADDC    R4, R24
+	ADDZE   R25
+	MOVDU   R24, 8(R10)
+	CMP     R0, R11
+	MOVD    R25, R4
+	BEQ     done
+
+	MOVD    8(R8), R20
+	MULLD   R9, R20, R24
+	MULHDU  R9, R20, R25
+	ADD     $-1, R11
+	ADDC    R4, R24
+	ADDZE   R25
+	MOVD    R24, 8(R10)
+	MOVD    R25, R4
+
+done:
+	MOVD    R4, c+64(FP)
+	RET
+
+// func addMulVVW(z, x []Word, y Word) (c Word)
+TEXT ·addMulVVW(SB), NOSPLIT, $0
+	MOVD z+0(FP), R10	// R10 = z[]
+	MOVD x+24(FP), R8	// R8 = x[]
+	MOVD y+48(FP), R9	// R9 = y
+	MOVD z_len+8(FP), R22	// R22 = z_len
+
+	MOVD R0, R3		// R3 will be the index register
+	CMP  R0, R22
+	MOVD R0, R4		// R4 = c = 0
+	MOVD R22, CTR		// Initialize loop counter
+	BEQ  done
+
+loop:
+	MOVD  (R8)(R3), R20	// Load x[i]
+	MOVD  (R10)(R3), R21	// Load z[i]
+	MULLD  R9, R20, R6	// R6 = Low-order(x[i]*y)
+	MULHDU R9, R20, R7	// R7 = High-order(x[i]*y)
+	ADDC   R21, R6		// R6 = z0
+	ADDZE  R7		// R7 = z1
+	ADDC   R4, R6		// R6 = z0 + c + 0
+	ADDZE  R7, R4           // c += z1
+	MOVD   R6, (R10)(R3)	// Store z[i]
+	ADD    $8, R3
+	BC  16, 0, loop		// bdnz
+
+done:
+	MOVD R4, c+56(FP)
+	RET

--- a/arith_riscv64.s
+++ b/arith_riscv64.s
@@ -1,0 +1,47 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE_go file.
+
+//go:build !math_big_pure_go && riscv64
+// +build !math_big_pure_go,riscv64
+
+#include "textflag.h"
+
+// This file provides fast assembly versions for the elementary
+// arithmetic operations on vectors implemented in arith.go.
+
+// func mulWW(x, y Word) (z1, z0 Word)
+TEXT ·mulWW(SB),NOSPLIT,$0
+	MOV	x+0(FP), X5
+	MOV	y+8(FP), X6
+	MULHU	X5, X6, X7
+	MUL	X5, X6, X8
+	MOV	X7, z1+16(FP)
+	MOV	X8, z0+24(FP)
+	RET
+
+
+TEXT ·addVV(SB),NOSPLIT,$0
+	JMP ·addVV_g(SB)
+
+TEXT ·subVV(SB),NOSPLIT,$0
+	JMP ·subVV_g(SB)
+
+TEXT ·addVW(SB),NOSPLIT,$0
+	JMP ·addVW_g(SB)
+
+TEXT ·subVW(SB),NOSPLIT,$0
+	JMP ·subVW_g(SB)
+
+TEXT ·shlVU(SB),NOSPLIT,$0
+	JMP ·shlVU_g(SB)
+
+TEXT ·shrVU(SB),NOSPLIT,$0
+	JMP ·shrVU_g(SB)
+
+TEXT ·mulAddVWW(SB),NOSPLIT,$0
+	JMP ·mulAddVWW_g(SB)
+
+TEXT ·addMulVVW(SB),NOSPLIT,$0
+	JMP ·addMulVVW_g(SB)
+

--- a/arith_s390x.s
+++ b/arith_s390x.s
@@ -1,0 +1,796 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE_go file.
+
+//go:build !math_big_pure_go
+// +build !math_big_pure_go
+
+#include "textflag.h"
+
+// This file provides fast assembly versions for the elementary
+// arithmetic operations on vectors implemented in arith.go.
+
+TEXT ·mulWW(SB), NOSPLIT, $0
+	MOVD   x+0(FP), R3
+	MOVD   y+8(FP), R4
+	MULHDU R3, R4
+	MOVD   R10, z1+16(FP)
+	MOVD   R11, z0+24(FP)
+	RET
+
+
+// DI = R3, CX = R4, SI = r10, r8 = r8, r9=r9, r10 = r2, r11 = r5, r12 = r6, r13 = r7, r14 = r1 (R0 set to 0) + use R11
+// func addVV(z, x, y []Word) (c Word)
+
+TEXT ·addVV(SB), NOSPLIT, $0
+	MOVD addvectorfacility+0x00(SB), R1
+	BR   (R1)
+
+TEXT ·addVV_check(SB), NOSPLIT, $0
+	MOVB   ·hasVX(SB), R1
+	CMPBEQ R1, $1, vectorimpl              // vectorfacility = 1, vector supported
+	MOVD   $addvectorfacility+0x00(SB), R1
+	MOVD   $·addVV_novec(SB), R2
+	MOVD   R2, 0(R1)
+
+	// MOVD	$·addVV_novec(SB), 0(R1)
+	BR ·addVV_novec(SB)
+
+vectorimpl:
+	MOVD $addvectorfacility+0x00(SB), R1
+	MOVD $·addVV_vec(SB), R2
+	MOVD R2, 0(R1)
+
+	// MOVD	$·addVV_vec(SB), 0(R1)
+	BR ·addVV_vec(SB)
+
+GLOBL addvectorfacility+0x00(SB), NOPTR, $8
+DATA addvectorfacility+0x00(SB)/8, $·addVV_check(SB)
+
+TEXT ·addVV_vec(SB), NOSPLIT, $0
+	MOVD z_len+8(FP), R3
+	MOVD x+24(FP), R8
+	MOVD y+48(FP), R9
+	MOVD z+0(FP), R2
+
+	MOVD $0, R4  // c = 0
+	MOVD $0, R0  // make sure it's zero
+	MOVD $0, R10 // i = 0
+
+	// s/JL/JMP/ below to disable the unrolled loop
+	SUB $4, R3
+	BLT v1
+	SUB $12, R3 // n -= 16
+	BLT A1      // if n < 0 goto A1
+
+	MOVD R8, R5
+	MOVD R9, R6
+	MOVD R2, R7
+
+	// n >= 0
+	// regular loop body unrolled 16x
+	VZERO V0 // c = 0
+
+UU1:
+	VLM  0(R5), V1, V4    // 64-bytes into V1..V8
+	ADD  $64, R5
+	VPDI $0x4, V1, V1, V1 // flip the doublewords to big-endian order
+	VPDI $0x4, V2, V2, V2 // flip the doublewords to big-endian order
+
+	VLM  0(R6), V9, V12      // 64-bytes into V9..V16
+	ADD  $64, R6
+	VPDI $0x4, V9, V9, V9    // flip the doublewords to big-endian order
+	VPDI $0x4, V10, V10, V10 // flip the doublewords to big-endian order
+
+	VACCCQ V1, V9, V0, V25
+	VACQ   V1, V9, V0, V17
+	VACCCQ V2, V10, V25, V26
+	VACQ   V2, V10, V25, V18
+
+	VLM 0(R5), V5, V6   // 32-bytes into V1..V8
+	VLM 0(R6), V13, V14 // 32-bytes into V9..V16
+	ADD $32, R5
+	ADD $32, R6
+
+	VPDI $0x4, V3, V3, V3    // flip the doublewords to big-endian order
+	VPDI $0x4, V4, V4, V4    // flip the doublewords to big-endian order
+	VPDI $0x4, V11, V11, V11 // flip the doublewords to big-endian order
+	VPDI $0x4, V12, V12, V12 // flip the doublewords to big-endian order
+
+	VACCCQ V3, V11, V26, V27
+	VACQ   V3, V11, V26, V19
+	VACCCQ V4, V12, V27, V28
+	VACQ   V4, V12, V27, V20
+
+	VLM 0(R5), V7, V8   // 32-bytes into V1..V8
+	VLM 0(R6), V15, V16 // 32-bytes into V9..V16
+	ADD $32, R5
+	ADD $32, R6
+
+	VPDI $0x4, V5, V5, V5    // flip the doublewords to big-endian order
+	VPDI $0x4, V6, V6, V6    // flip the doublewords to big-endian order
+	VPDI $0x4, V13, V13, V13 // flip the doublewords to big-endian order
+	VPDI $0x4, V14, V14, V14 // flip the doublewords to big-endian order
+
+	VACCCQ V5, V13, V28, V29
+	VACQ   V5, V13, V28, V21
+	VACCCQ V6, V14, V29, V30
+	VACQ   V6, V14, V29, V22
+
+	VPDI $0x4, V7, V7, V7    // flip the doublewords to big-endian order
+	VPDI $0x4, V8, V8, V8    // flip the doublewords to big-endian order
+	VPDI $0x4, V15, V15, V15 // flip the doublewords to big-endian order
+	VPDI $0x4, V16, V16, V16 // flip the doublewords to big-endian order
+
+	VACCCQ V7, V15, V30, V31
+	VACQ   V7, V15, V30, V23
+	VACCCQ V8, V16, V31, V0  // V0 has carry-over
+	VACQ   V8, V16, V31, V24
+
+	VPDI  $0x4, V17, V17, V17 // flip the doublewords to big-endian order
+	VPDI  $0x4, V18, V18, V18 // flip the doublewords to big-endian order
+	VPDI  $0x4, V19, V19, V19 // flip the doublewords to big-endian order
+	VPDI  $0x4, V20, V20, V20 // flip the doublewords to big-endian order
+	VPDI  $0x4, V21, V21, V21 // flip the doublewords to big-endian order
+	VPDI  $0x4, V22, V22, V22 // flip the doublewords to big-endian order
+	VPDI  $0x4, V23, V23, V23 // flip the doublewords to big-endian order
+	VPDI  $0x4, V24, V24, V24 // flip the doublewords to big-endian order
+	VSTM  V17, V24, 0(R7)     // 128-bytes into z
+	ADD   $128, R7
+	ADD   $128, R10           // i += 16
+	SUB   $16, R3             // n -= 16
+	BGE   UU1                 // if n >= 0 goto U1
+	VLGVG $1, V0, R4          // put cf into R4
+	NEG   R4, R4              // save cf
+
+A1:
+	ADD $12, R3 // n += 16
+
+	// s/JL/JMP/ below to disable the unrolled loop
+	BLT v1 // if n < 0 goto v1
+
+U1:  // n >= 0
+	// regular loop body unrolled 4x
+	MOVD 0(R8)(R10*1), R5
+	MOVD 8(R8)(R10*1), R6
+	MOVD 16(R8)(R10*1), R7
+	MOVD 24(R8)(R10*1), R1
+	ADDC R4, R4             // restore CF
+	MOVD 0(R9)(R10*1), R11
+	ADDE R11, R5
+	MOVD 8(R9)(R10*1), R11
+	ADDE R11, R6
+	MOVD 16(R9)(R10*1), R11
+	ADDE R11, R7
+	MOVD 24(R9)(R10*1), R11
+	ADDE R11, R1
+	MOVD R0, R4
+	ADDE R4, R4             // save CF
+	NEG  R4, R4
+	MOVD R5, 0(R2)(R10*1)
+	MOVD R6, 8(R2)(R10*1)
+	MOVD R7, 16(R2)(R10*1)
+	MOVD R1, 24(R2)(R10*1)
+
+	ADD $32, R10 // i += 4
+	SUB $4, R3   // n -= 4
+	BGE U1       // if n >= 0 goto U1
+
+v1:
+	ADD $4, R3 // n += 4
+	BLE E1     // if n <= 0 goto E1
+
+L1:  // n > 0
+	ADDC R4, R4            // restore CF
+	MOVD 0(R8)(R10*1), R5
+	MOVD 0(R9)(R10*1), R11
+	ADDE R11, R5
+	MOVD R5, 0(R2)(R10*1)
+	MOVD R0, R4
+	ADDE R4, R4            // save CF
+	NEG  R4, R4
+
+	ADD $8, R10 // i++
+	SUB $1, R3  // n--
+	BGT L1      // if n > 0 goto L1
+
+E1:
+	NEG  R4, R4
+	MOVD R4, c+72(FP) // return c
+	RET
+
+TEXT ·addVV_novec(SB), NOSPLIT, $0
+novec:
+	MOVD z_len+8(FP), R3
+	MOVD x+24(FP), R8
+	MOVD y+48(FP), R9
+	MOVD z+0(FP), R2
+
+	MOVD $0, R4  // c = 0
+	MOVD $0, R0  // make sure it's zero
+	MOVD $0, R10 // i = 0
+
+	// s/JL/JMP/ below to disable the unrolled loop
+	SUB $4, R3 // n -= 4
+	BLT v1n    // if n < 0 goto v1n
+
+U1n:  // n >= 0
+	// regular loop body unrolled 4x
+	MOVD 0(R8)(R10*1), R5
+	MOVD 8(R8)(R10*1), R6
+	MOVD 16(R8)(R10*1), R7
+	MOVD 24(R8)(R10*1), R1
+	ADDC R4, R4             // restore CF
+	MOVD 0(R9)(R10*1), R11
+	ADDE R11, R5
+	MOVD 8(R9)(R10*1), R11
+	ADDE R11, R6
+	MOVD 16(R9)(R10*1), R11
+	ADDE R11, R7
+	MOVD 24(R9)(R10*1), R11
+	ADDE R11, R1
+	MOVD R0, R4
+	ADDE R4, R4             // save CF
+	NEG  R4, R4
+	MOVD R5, 0(R2)(R10*1)
+	MOVD R6, 8(R2)(R10*1)
+	MOVD R7, 16(R2)(R10*1)
+	MOVD R1, 24(R2)(R10*1)
+
+	ADD $32, R10 // i += 4
+	SUB $4, R3   // n -= 4
+	BGE U1n      // if n >= 0 goto U1n
+
+v1n:
+	ADD $4, R3 // n += 4
+	BLE E1n    // if n <= 0 goto E1n
+
+L1n:  // n > 0
+	ADDC R4, R4            // restore CF
+	MOVD 0(R8)(R10*1), R5
+	MOVD 0(R9)(R10*1), R11
+	ADDE R11, R5
+	MOVD R5, 0(R2)(R10*1)
+	MOVD R0, R4
+	ADDE R4, R4            // save CF
+	NEG  R4, R4
+
+	ADD $8, R10 // i++
+	SUB $1, R3  // n--
+	BGT L1n     // if n > 0 goto L1n
+
+E1n:
+	NEG  R4, R4
+	MOVD R4, c+72(FP) // return c
+	RET
+
+TEXT ·subVV(SB), NOSPLIT, $0
+	MOVD subvectorfacility+0x00(SB), R1
+	BR   (R1)
+
+TEXT ·subVV_check(SB), NOSPLIT, $0
+	MOVB   ·hasVX(SB), R1
+	CMPBEQ R1, $1, vectorimpl              // vectorfacility = 1, vector supported
+	MOVD   $subvectorfacility+0x00(SB), R1
+	MOVD   $·subVV_novec(SB), R2
+	MOVD   R2, 0(R1)
+
+	// MOVD	$·subVV_novec(SB), 0(R1)
+	BR ·subVV_novec(SB)
+
+vectorimpl:
+	MOVD $subvectorfacility+0x00(SB), R1
+	MOVD $·subVV_vec(SB), R2
+	MOVD R2, 0(R1)
+
+	// MOVD	$·subVV_vec(SB), 0(R1)
+	BR ·subVV_vec(SB)
+
+GLOBL subvectorfacility+0x00(SB), NOPTR, $8
+DATA subvectorfacility+0x00(SB)/8, $·subVV_check(SB)
+
+// DI = R3, CX = R4, SI = r10, r8 = r8, r9=r9, r10 = r2, r11 = r5, r12 = r6, r13 = r7, r14 = r1 (R0 set to 0) + use R11
+// func subVV(z, x, y []Word) (c Word)
+// (same as addVV except for SUBC/SUBE instead of ADDC/ADDE and label names)
+TEXT ·subVV_vec(SB), NOSPLIT, $0
+	MOVD z_len+8(FP), R3
+	MOVD x+24(FP), R8
+	MOVD y+48(FP), R9
+	MOVD z+0(FP), R2
+	MOVD $0, R4          // c = 0
+	MOVD $0, R0          // make sure it's zero
+	MOVD $0, R10         // i = 0
+
+	// s/JL/JMP/ below to disable the unrolled loop
+	SUB $4, R3  // n -= 4
+	BLT v1      // if n < 0 goto v1
+	SUB $12, R3 // n -= 16
+	BLT A1      // if n < 0 goto A1
+
+	MOVD R8, R5
+	MOVD R9, R6
+	MOVD R2, R7
+
+	// n >= 0
+	// regular loop body unrolled 16x
+	VZERO V0         // cf = 0
+	MOVD  $1, R4     // for 390 subtraction cf starts as 1 (no borrow)
+	VLVGG $1, R4, V0 // put carry into V0
+
+UU1:
+	VLM  0(R5), V1, V4    // 64-bytes into V1..V8
+	ADD  $64, R5
+	VPDI $0x4, V1, V1, V1 // flip the doublewords to big-endian order
+	VPDI $0x4, V2, V2, V2 // flip the doublewords to big-endian order
+
+	VLM  0(R6), V9, V12      // 64-bytes into V9..V16
+	ADD  $64, R6
+	VPDI $0x4, V9, V9, V9    // flip the doublewords to big-endian order
+	VPDI $0x4, V10, V10, V10 // flip the doublewords to big-endian order
+
+	VSBCBIQ V1, V9, V0, V25
+	VSBIQ   V1, V9, V0, V17
+	VSBCBIQ V2, V10, V25, V26
+	VSBIQ   V2, V10, V25, V18
+
+	VLM 0(R5), V5, V6   // 32-bytes into V1..V8
+	VLM 0(R6), V13, V14 // 32-bytes into V9..V16
+	ADD $32, R5
+	ADD $32, R6
+
+	VPDI $0x4, V3, V3, V3    // flip the doublewords to big-endian order
+	VPDI $0x4, V4, V4, V4    // flip the doublewords to big-endian order
+	VPDI $0x4, V11, V11, V11 // flip the doublewords to big-endian order
+	VPDI $0x4, V12, V12, V12 // flip the doublewords to big-endian order
+
+	VSBCBIQ V3, V11, V26, V27
+	VSBIQ   V3, V11, V26, V19
+	VSBCBIQ V4, V12, V27, V28
+	VSBIQ   V4, V12, V27, V20
+
+	VLM 0(R5), V7, V8   // 32-bytes into V1..V8
+	VLM 0(R6), V15, V16 // 32-bytes into V9..V16
+	ADD $32, R5
+	ADD $32, R6
+
+	VPDI $0x4, V5, V5, V5    // flip the doublewords to big-endian order
+	VPDI $0x4, V6, V6, V6    // flip the doublewords to big-endian order
+	VPDI $0x4, V13, V13, V13 // flip the doublewords to big-endian order
+	VPDI $0x4, V14, V14, V14 // flip the doublewords to big-endian order
+
+	VSBCBIQ V5, V13, V28, V29
+	VSBIQ   V5, V13, V28, V21
+	VSBCBIQ V6, V14, V29, V30
+	VSBIQ   V6, V14, V29, V22
+
+	VPDI $0x4, V7, V7, V7    // flip the doublewords to big-endian order
+	VPDI $0x4, V8, V8, V8    // flip the doublewords to big-endian order
+	VPDI $0x4, V15, V15, V15 // flip the doublewords to big-endian order
+	VPDI $0x4, V16, V16, V16 // flip the doublewords to big-endian order
+
+	VSBCBIQ V7, V15, V30, V31
+	VSBIQ   V7, V15, V30, V23
+	VSBCBIQ V8, V16, V31, V0  // V0 has carry-over
+	VSBIQ   V8, V16, V31, V24
+
+	VPDI  $0x4, V17, V17, V17 // flip the doublewords to big-endian order
+	VPDI  $0x4, V18, V18, V18 // flip the doublewords to big-endian order
+	VPDI  $0x4, V19, V19, V19 // flip the doublewords to big-endian order
+	VPDI  $0x4, V20, V20, V20 // flip the doublewords to big-endian order
+	VPDI  $0x4, V21, V21, V21 // flip the doublewords to big-endian order
+	VPDI  $0x4, V22, V22, V22 // flip the doublewords to big-endian order
+	VPDI  $0x4, V23, V23, V23 // flip the doublewords to big-endian order
+	VPDI  $0x4, V24, V24, V24 // flip the doublewords to big-endian order
+	VSTM  V17, V24, 0(R7)     // 128-bytes into z
+	ADD   $128, R7
+	ADD   $128, R10           // i += 16
+	SUB   $16, R3             // n -= 16
+	BGE   UU1                 // if n >= 0 goto U1
+	VLGVG $1, V0, R4          // put cf into R4
+	SUB   $1, R4              // save cf
+
+A1:
+	ADD $12, R3 // n += 16
+	BLT v1      // if n < 0 goto v1
+
+U1:  // n >= 0
+	// regular loop body unrolled 4x
+	MOVD 0(R8)(R10*1), R5
+	MOVD 8(R8)(R10*1), R6
+	MOVD 16(R8)(R10*1), R7
+	MOVD 24(R8)(R10*1), R1
+	MOVD R0, R11
+	SUBC R4, R11            // restore CF
+	MOVD 0(R9)(R10*1), R11
+	SUBE R11, R5
+	MOVD 8(R9)(R10*1), R11
+	SUBE R11, R6
+	MOVD 16(R9)(R10*1), R11
+	SUBE R11, R7
+	MOVD 24(R9)(R10*1), R11
+	SUBE R11, R1
+	MOVD R0, R4
+	SUBE R4, R4             // save CF
+	MOVD R5, 0(R2)(R10*1)
+	MOVD R6, 8(R2)(R10*1)
+	MOVD R7, 16(R2)(R10*1)
+	MOVD R1, 24(R2)(R10*1)
+
+	ADD $32, R10 // i += 4
+	SUB $4, R3   // n -= 4
+	BGE U1       // if n >= 0 goto U1n
+
+v1:
+	ADD $4, R3 // n += 4
+	BLE E1     // if n <= 0 goto E1
+
+L1:  // n > 0
+	MOVD R0, R11
+	SUBC R4, R11           // restore CF
+	MOVD 0(R8)(R10*1), R5
+	MOVD 0(R9)(R10*1), R11
+	SUBE R11, R5
+	MOVD R5, 0(R2)(R10*1)
+	MOVD R0, R4
+	SUBE R4, R4            // save CF
+
+	ADD $8, R10 // i++
+	SUB $1, R3  // n--
+	BGT L1      // if n > 0 goto L1n
+
+E1:
+	NEG  R4, R4
+	MOVD R4, c+72(FP) // return c
+	RET
+
+// DI = R3, CX = R4, SI = r10, r8 = r8, r9=r9, r10 = r2, r11 = r5, r12 = r6, r13 = r7, r14 = r1 (R0 set to 0) + use R11
+// func subVV(z, x, y []Word) (c Word)
+// (same as addVV except for SUBC/SUBE instead of ADDC/ADDE and label names)
+TEXT ·subVV_novec(SB), NOSPLIT, $0
+	MOVD z_len+8(FP), R3
+	MOVD x+24(FP), R8
+	MOVD y+48(FP), R9
+	MOVD z+0(FP), R2
+
+	MOVD $0, R4  // c = 0
+	MOVD $0, R0  // make sure it's zero
+	MOVD $0, R10 // i = 0
+
+	// s/JL/JMP/ below to disable the unrolled loop
+	SUB $4, R3 // n -= 4
+	BLT v1     // if n < 0 goto v1
+
+U1:  // n >= 0
+	// regular loop body unrolled 4x
+	MOVD 0(R8)(R10*1), R5
+	MOVD 8(R8)(R10*1), R6
+	MOVD 16(R8)(R10*1), R7
+	MOVD 24(R8)(R10*1), R1
+	MOVD R0, R11
+	SUBC R4, R11            // restore CF
+	MOVD 0(R9)(R10*1), R11
+	SUBE R11, R5
+	MOVD 8(R9)(R10*1), R11
+	SUBE R11, R6
+	MOVD 16(R9)(R10*1), R11
+	SUBE R11, R7
+	MOVD 24(R9)(R10*1), R11
+	SUBE R11, R1
+	MOVD R0, R4
+	SUBE R4, R4             // save CF
+	MOVD R5, 0(R2)(R10*1)
+	MOVD R6, 8(R2)(R10*1)
+	MOVD R7, 16(R2)(R10*1)
+	MOVD R1, 24(R2)(R10*1)
+
+	ADD $32, R10 // i += 4
+	SUB $4, R3   // n -= 4
+	BGE U1       // if n >= 0 goto U1
+
+v1:
+	ADD $4, R3 // n += 4
+	BLE E1     // if n <= 0 goto E1
+
+L1:  // n > 0
+	MOVD R0, R11
+	SUBC R4, R11           // restore CF
+	MOVD 0(R8)(R10*1), R5
+	MOVD 0(R9)(R10*1), R11
+	SUBE R11, R5
+	MOVD R5, 0(R2)(R10*1)
+	MOVD R0, R4
+	SUBE R4, R4            // save CF
+
+	ADD $8, R10 // i++
+	SUB $1, R3  // n--
+	BGT L1      // if n > 0 goto L1
+
+E1:
+	NEG  R4, R4
+	MOVD R4, c+72(FP) // return c
+	RET
+
+TEXT ·addVW(SB), NOSPLIT, $0
+	MOVD z_len+8(FP), R5 // length of z
+	MOVD x+24(FP), R6
+	MOVD y+48(FP), R7    // c = y
+	MOVD z+0(FP), R8
+
+	CMPBEQ R5, $0, returnC // if len(z) == 0, we can have an early return
+
+	// Add the first two words, and determine which path (copy path or loop path) to take based on the carry flag.
+	ADDC   0(R6), R7
+	MOVD   R7, 0(R8)
+	CMPBEQ R5, $1, returnResult // len(z) == 1
+	MOVD   $0, R9
+	ADDE   8(R6), R9
+	MOVD   R9, 8(R8)
+	CMPBEQ R5, $2, returnResult // len(z) == 2
+
+	// Update the counters
+	MOVD $16, R12    // i = 2
+	MOVD $-2(R5), R5 // n = n - 2
+
+loopOverEachWord:
+	BRC  $12, copySetup // carry = 0, copy the rest
+	MOVD $1, R9
+
+	// Originally we used the carry flag generated in the previous iteration
+	// (i.e: ADDE could be used here to do the addition).  However, since we
+	// already know carry is 1 (otherwise we will go to copy section), we can use
+	// ADDC here so the current iteration does not depend on the carry flag
+	// generated in the previous iteration. This could be useful when branch prediction happens.
+	ADDC 0(R6)(R12*1), R9
+	MOVD R9, 0(R8)(R12*1) // z[i] = x[i] + c
+
+	MOVD  $8(R12), R12         // i++
+	BRCTG R5, loopOverEachWord // n--
+
+// Return the current carry value
+returnResult:
+	MOVD $0, R0
+	ADDE R0, R0
+	MOVD R0, c+56(FP)
+	RET
+
+// Update position of x(R6) and z(R8) based on the current counter value and perform copying.
+// With the assumption that x and z will not overlap with each other or x and z will
+// point to same memory region, we can use a faster version of copy using only MVC here.
+// In the following implementation, we have three copy loops, each copying a word, 4 words, and
+// 32 words at a time.  Via benchmarking, this implementation is faster than calling runtime·memmove.
+copySetup:
+	ADD R12, R6
+	ADD R12, R8
+
+	CMPBGE R5, $4, mediumLoop
+
+smallLoop:  // does a loop unrolling to copy word when n < 4
+	CMPBEQ R5, $0, returnZero
+	MVC    $8, 0(R6), 0(R8)
+	CMPBEQ R5, $1, returnZero
+	MVC    $8, 8(R6), 8(R8)
+	CMPBEQ R5, $2, returnZero
+	MVC    $8, 16(R6), 16(R8)
+
+returnZero:
+	MOVD $0, c+56(FP) // return 0 as carry
+	RET
+
+mediumLoop:
+	CMPBLT R5, $4, smallLoop
+	CMPBLT R5, $32, mediumLoopBody
+
+largeLoop:  // Copying 256 bytes at a time.
+	MVC    $256, 0(R6), 0(R8)
+	MOVD   $256(R6), R6
+	MOVD   $256(R8), R8
+	MOVD   $-32(R5), R5
+	CMPBGE R5, $32, largeLoop
+	BR     mediumLoop
+
+mediumLoopBody:  // Copying 32 bytes at a time
+	MVC    $32, 0(R6), 0(R8)
+	MOVD   $32(R6), R6
+	MOVD   $32(R8), R8
+	MOVD   $-4(R5), R5
+	CMPBGE R5, $4, mediumLoopBody
+	BR     smallLoop
+
+returnC:
+	MOVD R7, c+56(FP)
+	RET
+
+TEXT ·subVW(SB), NOSPLIT, $0
+	MOVD z_len+8(FP), R5
+	MOVD x+24(FP), R6
+	MOVD y+48(FP), R7    // The borrow bit passed in
+	MOVD z+0(FP), R8
+	MOVD $0, R0          // R0 is a temporary variable used during computation. Ensure it has zero in it.
+
+	CMPBEQ R5, $0, returnC // len(z) == 0, have an early return
+
+	// Subtract the first two words, and determine which path (copy path or loop path) to take based on the borrow flag
+	MOVD   0(R6), R9
+	SUBC   R7, R9
+	MOVD   R9, 0(R8)
+	CMPBEQ R5, $1, returnResult
+	MOVD   8(R6), R9
+	SUBE   R0, R9
+	MOVD   R9, 8(R8)
+	CMPBEQ R5, $2, returnResult
+
+	// Update the counters
+	MOVD $16, R12    // i = 2
+	MOVD $-2(R5), R5 // n = n - 2
+
+loopOverEachWord:
+	BRC  $3, copySetup    // no borrow, copy the rest
+	MOVD 0(R6)(R12*1), R9
+
+	// Originally we used the borrow flag generated in the previous iteration
+	// (i.e: SUBE could be used here to do the subtraction). However, since we
+	// already know borrow is 1 (otherwise we will go to copy section), we can
+	// use SUBC here so the current iteration does not depend on the borrow flag
+	// generated in the previous iteration. This could be useful when branch prediction happens.
+	SUBC $1, R9
+	MOVD R9, 0(R8)(R12*1) // z[i] = x[i] - 1
+
+	MOVD  $8(R12), R12         // i++
+	BRCTG R5, loopOverEachWord // n--
+
+// return the current borrow value
+returnResult:
+	SUBE R0, R0
+	NEG  R0, R0
+	MOVD R0, c+56(FP)
+	RET
+
+// Update position of x(R6) and z(R8) based on the current counter value and perform copying.
+// With the assumption that x and z will not overlap with each other or x and z will
+// point to same memory region, we can use a faster version of copy using only MVC here.
+// In the following implementation, we have three copy loops, each copying a word, 4 words, and
+// 32 words at a time. Via benchmarking, this implementation is faster than calling runtime·memmove.
+copySetup:
+	ADD R12, R6
+	ADD R12, R8
+
+	CMPBGE R5, $4, mediumLoop
+
+smallLoop:  // does a loop unrolling to copy word when n < 4
+	CMPBEQ R5, $0, returnZero
+	MVC    $8, 0(R6), 0(R8)
+	CMPBEQ R5, $1, returnZero
+	MVC    $8, 8(R6), 8(R8)
+	CMPBEQ R5, $2, returnZero
+	MVC    $8, 16(R6), 16(R8)
+
+returnZero:
+	MOVD $0, c+56(FP) // return 0 as borrow
+	RET
+
+mediumLoop:
+	CMPBLT R5, $4, smallLoop
+	CMPBLT R5, $32, mediumLoopBody
+
+largeLoop:  // Copying 256 bytes at a time
+	MVC    $256, 0(R6), 0(R8)
+	MOVD   $256(R6), R6
+	MOVD   $256(R8), R8
+	MOVD   $-32(R5), R5
+	CMPBGE R5, $32, largeLoop
+	BR     mediumLoop
+
+mediumLoopBody:  // Copying 32 bytes at a time
+	MVC    $32, 0(R6), 0(R8)
+	MOVD   $32(R6), R6
+	MOVD   $32(R8), R8
+	MOVD   $-4(R5), R5
+	CMPBGE R5, $4, mediumLoopBody
+	BR     smallLoop
+
+returnC:
+	MOVD R7, c+56(FP)
+	RET
+
+// func shlVU(z, x []Word, s uint) (c Word)
+TEXT ·shlVU(SB), NOSPLIT, $0
+	BR ·shlVU_g(SB)
+
+// func shrVU(z, x []Word, s uint) (c Word)
+TEXT ·shrVU(SB), NOSPLIT, $0
+	BR ·shrVU_g(SB)
+
+// CX = R4, r8 = r8, r9=r9, r10 = r2, r11 = r5, DX = r3, AX = r6, BX = R1, (R0 set to 0) + use R11 + use R7 for i
+// func mulAddVWW(z, x []Word, y, r Word) (c Word)
+TEXT ·mulAddVWW(SB), NOSPLIT, $0
+	MOVD z+0(FP), R2
+	MOVD x+24(FP), R8
+	MOVD y+48(FP), R9
+	MOVD r+56(FP), R4    // c = r
+	MOVD z_len+8(FP), R5
+	MOVD $0, R1          // i = 0
+	MOVD $0, R7          // i*8 = 0
+	MOVD $0, R0          // make sure it's zero
+	BR   E5
+
+L5:
+	MOVD   (R8)(R1*1), R6
+	MULHDU R9, R6
+	ADDC   R4, R11         // add to low order bits
+	ADDE   R0, R6
+	MOVD   R11, (R2)(R1*1)
+	MOVD   R6, R4
+	ADD    $8, R1          // i*8 + 8
+	ADD    $1, R7          // i++
+
+E5:
+	CMPBLT R7, R5, L5 // i < n
+
+	MOVD R4, c+64(FP)
+	RET
+
+// func addMulVVW(z, x []Word, y Word) (c Word)
+// CX = R4, r8 = r8, r9=r9, r10 = r2, r11 = r5, AX = r11, DX = R6, r12=r12, BX = R1, (R0 set to 0) + use R11 + use R7 for i
+TEXT ·addMulVVW(SB), NOSPLIT, $0
+	MOVD z+0(FP), R2
+	MOVD x+24(FP), R8
+	MOVD y+48(FP), R9
+	MOVD z_len+8(FP), R5
+
+	MOVD $0, R1 // i*8 = 0
+	MOVD $0, R7 // i = 0
+	MOVD $0, R0 // make sure it's zero
+	MOVD $0, R4 // c = 0
+
+	MOVD   R5, R12
+	AND    $-2, R12
+	CMPBGE R5, $2, A6
+	BR     E6
+
+A6:
+	MOVD   (R8)(R1*1), R6
+	MULHDU R9, R6
+	MOVD   (R2)(R1*1), R10
+	ADDC   R10, R11        // add to low order bits
+	ADDE   R0, R6
+	ADDC   R4, R11
+	ADDE   R0, R6
+	MOVD   R6, R4
+	MOVD   R11, (R2)(R1*1)
+
+	MOVD   (8)(R8)(R1*1), R6
+	MULHDU R9, R6
+	MOVD   (8)(R2)(R1*1), R10
+	ADDC   R10, R11           // add to low order bits
+	ADDE   R0, R6
+	ADDC   R4, R11
+	ADDE   R0, R6
+	MOVD   R6, R4
+	MOVD   R11, (8)(R2)(R1*1)
+
+	ADD $16, R1 // i*8 + 8
+	ADD $2, R7  // i++
+
+	CMPBLT R7, R12, A6
+	BR     E6
+
+L6:
+	MOVD   (R8)(R1*1), R6
+	MULHDU R9, R6
+	MOVD   (R2)(R1*1), R10
+	ADDC   R10, R11        // add to low order bits
+	ADDE   R0, R6
+	ADDC   R4, R11
+	ADDE   R0, R6
+	MOVD   R6, R4
+	MOVD   R11, (R2)(R1*1)
+
+	ADD $8, R1 // i*8 + 8
+	ADD $1, R7 // i++
+
+E6:
+	CMPBLT R7, R5, L6 // i < n
+
+	MOVD R4, c+56(FP)
+	RET
+

--- a/arith_s390x_test.go
+++ b/arith_s390x_test.go
@@ -1,0 +1,33 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE_go file.
+
+//go:build s390x && !math_big_pure_go
+// +build s390x,!math_big_pure_go
+
+package big
+
+import (
+	"testing"
+)
+
+// Tests whether the non vector routines are working, even when the tests are run on a
+// vector-capable machine
+
+func TestFunVVnovec(t *testing.T) {
+	if hasVX == true {
+		for _, a := range sumVV {
+			arg := a
+			testFunVV(t, "addVV_novec", addVV_novec, arg)
+
+			arg = argVV{a.z, a.y, a.x, a.c}
+			testFunVV(t, "addVV_novec symmetric", addVV_novec, arg)
+
+			arg = argVV{a.x, a.z, a.y, a.c}
+			testFunVV(t, "subVV_novec", subVV_novec, arg)
+
+			arg = argVV{a.y, a.z, a.x, a.c}
+			testFunVV(t, "subVV_novec symmetric", subVV_novec, arg)
+		}
+	}
+}

--- a/arith_wasm.s
+++ b/arith_wasm.s
@@ -1,0 +1,35 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE_go file.
+
+//go:build !math_big_pure_go
+// +build !math_big_pure_go
+
+#include "textflag.h"
+
+TEXT ·mulWW(SB),NOSPLIT,$0
+	JMP ·mulWW_g(SB)
+
+TEXT ·addVV(SB),NOSPLIT,$0
+	JMP ·addVV_g(SB)
+
+TEXT ·subVV(SB),NOSPLIT,$0
+	JMP ·subVV_g(SB)
+
+TEXT ·addVW(SB),NOSPLIT,$0
+	JMP ·addVW_g(SB)
+
+TEXT ·subVW(SB),NOSPLIT,$0
+	JMP ·subVW_g(SB)
+
+TEXT ·shlVU(SB),NOSPLIT,$0
+	JMP ·shlVU_g(SB)
+
+TEXT ·shrVU(SB),NOSPLIT,$0
+	JMP ·shrVU_g(SB)
+
+TEXT ·mulAddVWW(SB),NOSPLIT,$0
+	JMP ·mulAddVWW_g(SB)
+
+TEXT ·addMulVVW(SB),NOSPLIT,$0
+	JMP ·addMulVVW_g(SB)


### PR DESCRIPTION
This copies the assembly files from https://cs.opensource.google/go/go/+/master:src/math/big/, to add support for all of the architectures supported by math/big. Most of these just jump to the pure implementations, and shouldn't pose any constant-timeness issues.

The only one I'm somewhat unsure about is the s390x implementation, which does some loop unrolling for small limbed numbers, but it doesn't do early returns based on the evaluation results, like the amd64 did, before we modified it.

This should address #48, but I haven't tested building and running the tests, so closing that issue is pending on doing that.