### PR TITLE
Fix package name for s390x test

### DIFF
--- a/arith_s390x_test.go
+++ b/arith_s390x_test.go
@@ -5,7 +5,7 @@
 //go:build s390x && !math_big_pure_go
 // +build s390x,!math_big_pure_go
 
-package big
+package saferith
 
 import (
 	"testing"


### PR DESCRIPTION
The package name for the s390x test is `big` rather than `saferith` which causes builds on s390x systems to [fail](https://gitlab.alpinelinux.org/Celeste/aports/-/jobs/1109775).